### PR TITLE
trivial bugfix - use s:uniq() not uniq()

### DIFF
--- a/autoload/rails.vim
+++ b/autoload/rails.vim
@@ -2537,7 +2537,7 @@ function! s:completion_filter(results, A, ...) abort
   if exists('*projectionist#completion_filter')
     return projectionist#completion_filter(a:results, a:A, a:0 ? a:1 : '/')
   endif
-  let results = uniq(sort(type(a:results) == type("") ? split(a:results,"\n") : copy(a:results)))
+  let results = s:uniq(sort(type(a:results) == type("") ? split(a:results,"\n") : copy(a:results)))
   call filter(results,'v:val !~# "\\~$"')
   if a:A =~# '\*'
     let regex = s:gsub(a:A,'\*','.*')


### PR DESCRIPTION
Bug introduced in 31298088d888b87c235eab9239ff6124c46c8331.

Causes older versions of vim pre the uniq function to projectile vomit errors into your eyes when tab completing.
